### PR TITLE
GOのコード上でポインタからのセル参照を容易にするリファクタリング

### DIFF
--- a/storage/page.go
+++ b/storage/page.go
@@ -85,16 +85,6 @@ func newNonLeafPage() Page {
 	return pg
 }
 
-func (pg *Page) setPtrsFromBytes(numOfPtr uint32, bytes []byte) {
-	if int(numOfPtr*4) != len(bytes) {
-		panic(errors.New("bytes length must be 4 * numOfPtr"))
-	}
-	pg.ptrs = make([]uint32, numOfPtr)
-	for i := 0; i < int(numOfPtr); i++ {
-		pg.ptrs[i] = binary.BigEndian.Uint32(bytes[i*4 : (i+1)*4])
-	}
-}
-
 func (pg *Page) getContentSize() (size uint32) {
 	size = 0
 	for _, c := range pg.cells {

--- a/storage/page.go
+++ b/storage/page.go
@@ -61,13 +61,6 @@ func newPageFromBytes(bytes []byte) Page {
 		if ptr < uint32(min) {
 			min = ptr
 		}
-		// var cell Cell
-		// if pg.header.isLeaf {
-		// 	cell = Record{}.fromBytes(bytes[ptr:])
-		// } else {
-		// 	cell = KeyCell{}.fromBytes(bytes[ptr:])
-		// }
-		// pg.cells = append(pg.cells, cell)
 	}
 	cur := min
 	for i := 0; i < int(pg.header.numOfPtr); i++ {

--- a/storage/page.go
+++ b/storage/page.go
@@ -58,7 +58,7 @@ func newPageFromBytes(bytes []byte) Page {
 	ptrRawValues := make(map[uint32]int, pg.header.numOfPtr)
 	ptrRawValuesSorted := make([]uint32, pg.header.numOfPtr)
 	for i := 0; i < int(pg.header.numOfPtr); i++ {
-		value := binary.BigEndian.Uint32(bytes[int(pg.headerSize())+i*4 : int(pg.headerSize())+(i+1)*4])
+		value := binary.BigEndian.Uint32(bytes[PageHeaderSize+i*4 : PageHeaderSize+(i+1)*4])
 		ptrRawValues[value] = i
 		ptrRawValuesSorted[i] = value
 	}
@@ -95,10 +95,6 @@ func (pg *Page) setPtrsFromBytes(numOfPtr uint32, bytes []byte) {
 	}
 }
 
-func (pg *Page) headerSize() uint32 {
-	return 5
-}
-
 func (pg *Page) getContentSize() (size uint32) {
 	size = 0
 	for _, c := range pg.cells {
@@ -111,7 +107,7 @@ func (pg *Page) addRecord(rec Record) (bool, uint32) {
 	if !pg.header.isLeaf {
 		return false, 0
 	}
-	if pg.headerSize()+4*(pg.header.numOfPtr+1) > PageSize-pg.getContentSize()-rec.getSize() {
+	if PageHeaderSize+4*(pg.header.numOfPtr+1) > PageSize-pg.getContentSize()-rec.getSize() {
 		return false, 0
 	}
 
@@ -136,7 +132,7 @@ func (pg *Page) addKeyCell(cell KeyCell) {
 	if pg.header.isLeaf {
 		panic(errors.New("cannot add KeyCell to Leaf Page"))
 	}
-	if pg.headerSize()+4*(pg.header.numOfPtr+1) > PageSize-pg.getContentSize()-cell.getSize() {
+	if PageHeaderSize+4*(pg.header.numOfPtr+1) > PageSize-pg.getContentSize()-cell.getSize() {
 		panic(errors.New("full root page"))
 	}
 	idx := pg.locateLocally(cell.key)

--- a/storage/page.go
+++ b/storage/page.go
@@ -16,7 +16,7 @@ type PageHeader struct {
 }
 
 func (header PageHeader) toBytes() []byte {
-	buf := make([]byte, 5)
+	buf := make([]byte, PageHeaderSize)
 	if header.isLeaf {
 		buf[0] = 1
 	} else {
@@ -54,7 +54,7 @@ func newPageFromBytes(bytes []byte) Page {
 		panic(errors.New("bytes length must be PageSize"))
 	}
 	pg := Page{}
-	pg.header = newPageHeaderFromBytes(bytes[:5])
+	pg.header = newPageHeaderFromBytes(bytes[:PageHeaderSize])
 	ptrRawValues := make(map[uint32]int, pg.header.numOfPtr)
 	ptrRawValuesSorted := make([]uint32, pg.header.numOfPtr)
 	for i := 0; i < int(pg.header.numOfPtr); i++ {
@@ -135,7 +135,7 @@ func (pg *Page) addKeyCell(cell KeyCell) {
 
 func (pg *Page) toBytes() []byte {
 	buf := make([]byte, PageSize)
-	copy(buf[:5], pg.header.toBytes())
+	copy(buf[:PageHeaderSize], pg.header.toBytes())
 	ptrRawValues := make([]uint32, pg.header.numOfPtr)
 	cur := PageSize
 	for i, cell := range pg.cells {
@@ -145,7 +145,7 @@ func (pg *Page) toBytes() []byte {
 	}
 	for i, ptr := range pg.ptrs {
 		rawValue := ptrRawValues[int(ptr)]
-		binary.BigEndian.PutUint32(buf[5+i*4:5+(i+1)*4], rawValue)
+		binary.BigEndian.PutUint32(buf[PageHeaderSize+i*4:PageHeaderSize+(i+1)*4], rawValue)
 	}
 	return buf
 }

--- a/storage/table.go
+++ b/storage/table.go
@@ -123,7 +123,7 @@ func (t *Table) selectInt(col Column) (res []int32, err error) {
 	}
 	root := t.pages[0]
 	for i := 0; i < int(root.header.numOfPtr); i++ {
-		idx := ((PageSize - root.ptrs[i]) / KeyCellSize) - 1
+		idx := root.ptrs[i]
 		keyCell := root.cells[idx].(KeyCell)
 		rec := t.pages[keyCell.pageIndex].cells[keyCell.ptrIndex].(Record)
 		bytes := rec.data[col.pos : col.pos+col.ty.size]


### PR DESCRIPTION
- 不要なコメントを削除y
- :refactor: GOのコード上でポインタからセルへのアクセスをやりやすくする
- PageHeaderSizeは定数のはずなのでgetHeaderSize()を削除y
- delete unused function
- ハードコーディングしてる5の代わりになるべくPageHeaderSizeを使用
