### PR TITLE
Makefileとlinterの追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+test:
+	go test -v ./...
+test_storage:
+	go test -v ./storage
+install:
+	go install honnef.co/go/tools/cmd/staticcheck@v0.2.0
+lint:
+	staticcheck ./...

--- a/README.md
+++ b/README.md
@@ -1,11 +1,16 @@
 # tychyDB
 tychy and yokonao challenge to implement relational database
 
-## Testing
+## setup
+Please run the following command for install dependencies.
+```
+make install
+```
+## Command
 ```
 // run all test
-go test -v ./...
+make test
 
-// run specified package test
-got test -v ./parser
+// run linter
+make lint
 ```


### PR DESCRIPTION
`make install`するとlinterである`staticcheck`がインストールされます。
CLIからは`make lint`でlinterをかけれます