### PR TITLE
B+Treeの実装

### DIFF
--- a/storage/buffermgr.go
+++ b/storage/buffermgr.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 )
 
-const MaxBufferPoolSize = 5
+const MaxBufferPoolSize = 15
 
 type PageTable struct {
 	table map[int]int

--- a/storage/cell.go
+++ b/storage/cell.go
@@ -58,3 +58,26 @@ func (cell KeyCell) fromBytes(bytes []byte) Cell {
 	cell.pageIndex = binary.BigEndian.Uint32(bytes[4:8])
 	return cell
 }
+
+type KeyValueCell struct {
+	key int32
+	rec Record
+}
+
+func (cell KeyValueCell) getSize() uint32 {
+	return cell.rec.getSize() + 4
+}
+
+func (cell KeyValueCell) toBytes() []byte {
+	buf := make([]byte, cell.getSize())
+	binary.BigEndian.PutUint32(buf[:4], uint32(cell.key))
+	copy(buf[4:], cell.rec.toBytes())
+	return buf
+}
+
+func (cell KeyValueCell) fromBytes(bytes []byte) Cell {
+	cell.key = int32(binary.BigEndian.Uint32(bytes[:4]))
+	rec := Record{}
+	cell.rec = rec.fromBytes(bytes[4:]).(Record)
+	return cell
+}

--- a/storage/page.go
+++ b/storage/page.go
@@ -197,36 +197,6 @@ func (pg *Page) addRecordRec(rec Record) (splitted bool, splitKey int32, leftPag
 	return
 }
 
-func (pg *Page) addRecord(rec Record) bool {
-	if !pg.header.isLeaf {
-		return false
-	}
-	if (PageSize - pg.getPageSize()) < (4 + rec.getSize()) {
-		return false
-	}
-
-	pg.ptrs = append(pg.ptrs, pg.header.numOfPtr)
-	pg.cells = append(pg.cells, rec)
-	pg.header.numOfPtr++
-	return true
-}
-
-func (pg *Page) addKeyCell(cell KeyCell) {
-	if pg.header.isLeaf {
-		panic(errors.New("cannot add KeyCell to Leaf Page"))
-	}
-
-	if (PageSize - pg.getPageSize()) < (4 + cell.getSize()) {
-		panic(errors.New("full root page"))
-	}
-	idx := pg.locateLocally(cell.key)
-	pg.ptrs = append(pg.ptrs, 0)
-	copy(pg.ptrs[idx+1:], pg.ptrs[idx:])
-	pg.ptrs[idx] = pg.header.numOfPtr
-	pg.cells = append(pg.cells, cell)
-	pg.header.numOfPtr++
-}
-
 func (pg *Page) toBytes() []byte {
 	buf := make([]byte, PageSize)
 	copy(buf[:PageHeaderSize], pg.header.toBytes())

--- a/storage/page.go
+++ b/storage/page.go
@@ -10,7 +10,6 @@ const PageSize = 4096
 const PageHeaderSize = 5
 
 type PageHeader struct {
-	// total 5 byte
 	isLeaf   bool
 	numOfPtr uint32
 }
@@ -42,11 +41,11 @@ type Page struct {
 }
 
 func newPage() *Page {
-	pg := Page{}
+	pg := &Page{}
 	pg.header = PageHeader{isLeaf: true, numOfPtr: 0}
 	pg.ptrs = make([]uint32, 0)
 	pg.cells = make([]Cell, 0)
-	return &pg
+	return pg
 }
 
 type ptrCellPair struct {
@@ -58,7 +57,7 @@ func newPageFromBytes(bytes []byte) *Page {
 	if len(bytes) != PageSize {
 		panic(errors.New("bytes length must be PageSize"))
 	}
-	pg := Page{}
+	pg := &Page{}
 	pg.header = newPageHeaderFromBytes(bytes[:PageHeaderSize])
 	ptrCellPairs := make([]ptrCellPair, pg.header.numOfPtr)
 	for i := 0; i < int(pg.header.numOfPtr); i++ {
@@ -77,15 +76,15 @@ func newPageFromBytes(bytes []byte) *Page {
 		pg.cells = append(pg.cells, cell)
 		pg.ptrs[item.ptrIndex] = uint32(i)
 	}
-	return &pg
+	return pg
 }
 
 func newNonLeafPage() *Page {
-	pg := Page{}
+	pg := &Page{}
 	pg.header = PageHeader{isLeaf: false, numOfPtr: 0}
 	pg.ptrs = make([]uint32, 0)
 	pg.cells = make([]Cell, 0)
-	return &pg
+	return pg
 }
 
 func (pg *Page) getContentSize() (size uint32) {

--- a/storage/page.go
+++ b/storage/page.go
@@ -99,6 +99,16 @@ func (pg *Page) getPageSize() uint32 {
 	return PageHeaderSize + 4*pg.header.numOfPtr + pg.getContentSize()
 }
 
+func (pg *Page) locateLocally(key int32) uint32 {
+	for i, ptr := range pg.ptrs {
+		compared := pg.cells[ptr].(KeyCell).key
+		if key < compared {
+			return uint32(i)
+		}
+	}
+	return pg.header.numOfPtr
+}
+
 func (pg *Page) addRecord(rec Record) bool {
 	if !pg.header.isLeaf {
 		return false
@@ -111,17 +121,6 @@ func (pg *Page) addRecord(rec Record) bool {
 	pg.cells = append(pg.cells, rec)
 	pg.header.numOfPtr++
 	return true
-}
-
-func (pg *Page) locateLocally(key int32) (res uint32) {
-	res = pg.header.numOfPtr
-	for i, ptr := range pg.ptrs {
-		compared := pg.cells[ptr].(KeyCell).key
-		if key < compared {
-			return uint32(i)
-		}
-	}
-	return
 }
 
 func (pg *Page) addKeyCell(cell KeyCell) {

--- a/storage/page.go
+++ b/storage/page.go
@@ -7,11 +7,12 @@ import (
 )
 
 const PageSize = 4096
-const PageHeaderSize = 5
+const PageHeaderSize = 9
 
 type PageHeader struct {
-	isLeaf   bool
-	numOfPtr uint32
+	isLeaf       bool
+	numOfPtr     uint32
+	rightmostPtr uint32
 }
 
 func (header PageHeader) toBytes() []byte {

--- a/storage/page.go
+++ b/storage/page.go
@@ -95,11 +95,15 @@ func (pg *Page) getContentSize() (size uint32) {
 	return
 }
 
+func (pg *Page) getPageSize() uint32 {
+	return PageHeaderSize + 4*pg.header.numOfPtr + pg.getContentSize()
+}
+
 func (pg *Page) addRecord(rec Record) bool {
 	if !pg.header.isLeaf {
 		return false
 	}
-	if PageHeaderSize+4*(pg.header.numOfPtr+1) > PageSize-pg.getContentSize()-rec.getSize() {
+	if (PageSize - pg.getPageSize()) < (4 + rec.getSize()) {
 		return false
 	}
 
@@ -124,7 +128,8 @@ func (pg *Page) addKeyCell(cell KeyCell) {
 	if pg.header.isLeaf {
 		panic(errors.New("cannot add KeyCell to Leaf Page"))
 	}
-	if PageHeaderSize+4*(pg.header.numOfPtr+1) > PageSize-pg.getContentSize()-cell.getSize() {
+
+	if (PageSize - pg.getPageSize()) < (4 + cell.getSize()) {
 		panic(errors.New("full root page"))
 	}
 	idx := pg.locateLocally(cell.key)

--- a/storage/queue.go
+++ b/storage/queue.go
@@ -1,0 +1,42 @@
+package storage
+
+import "errors"
+
+type Queue struct {
+	b []int
+	h int // 最初の要素のインデックス
+	t int // 空き領域の先頭のインデックス
+}
+
+func NewQueue(n int) Queue {
+	q := Queue{}
+	q.b = make([]int, n)
+	q.h = 0
+	q.t = 0
+	return q
+}
+
+func (q *Queue) IsEmpty() bool {
+	return q.h == q.t
+}
+
+func (q *Queue) Size() int {
+	return (q.t - q.h + len(q.b)) % len(q.b)
+}
+
+func (q *Queue) Push(x int) {
+	if q.Size() >= len(q.b) {
+		panic(errors.New("queue is full, cannot push"))
+	}
+	q.b[q.t] = x
+	q.t = (q.t + 1) % len(q.b)
+}
+
+func (q *Queue) Pop() (res int) {
+	if q.IsEmpty() {
+		panic(errors.New("queue is empty, cannot pop"))
+	}
+	res = q.b[q.h]
+	q.h = (q.h + 1) % len(q.b)
+	return
+}

--- a/storage/queue.go
+++ b/storage/queue.go
@@ -1,6 +1,8 @@
 package storage
 
-import "errors"
+import (
+	"errors"
+)
 
 type Queue struct {
 	b []int
@@ -25,8 +27,10 @@ func (q *Queue) Size() int {
 }
 
 func (q *Queue) Push(x int) {
-	if q.Size() >= len(q.b) {
-		panic(errors.New("queue is full, cannot push"))
+	if q.Size()+1 >= len(q.b) {
+		buff := make([]int, 4*len(q.b))
+		copy(buff[:len(q.b)], q.b)
+		q.b = buff
 	}
 	q.b[q.t] = x
 	q.t = (q.t + 1) % len(q.b)

--- a/storage/queue_test.go
+++ b/storage/queue_test.go
@@ -1,0 +1,56 @@
+package storage_test
+
+import (
+	"testing"
+
+	"github.com/tychyDB/storage"
+)
+
+func TestQueue(t *testing.T) {
+	q := storage.NewQueue(10)
+	q.Push(10)
+	q.Push(11)
+	res := q.Pop()
+	if res != 10 {
+		t.Errorf("expected: 10, actual: %d", res)
+	}
+
+	res = q.Pop()
+	if res != 11 {
+		t.Errorf("expected: 11, actual: %d", res)
+	}
+
+	q.Push(12)
+	q.Push(13)
+	q.Push(14)
+	q.Push(15)
+	q.Push(16)
+	q.Push(17)
+	q.Push(18)
+	q.Push(19)
+	q.Push(20)
+	for i := 12; i <= 20; i++ {
+		res = q.Pop()
+		if res != i {
+			t.Errorf("expected: %d, actual: %d", i, res)
+		}
+
+	}
+	// これでq.hが一周する
+	q.Push(12)
+	q.Push(13)
+	q.Push(14)
+	q.Push(15)
+	q.Push(16)
+	q.Push(17)
+	q.Push(18)
+	q.Push(19)
+	q.Push(20)
+	for i := 12; i <= 20; i++ {
+		res = q.Pop()
+		if res != i {
+			t.Errorf("expected: %d, actual: %d", i, res)
+		}
+	}
+
+}

--- a/storage/queue_test.go
+++ b/storage/queue_test.go
@@ -1,6 +1,7 @@
 package storage_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/tychyDB/storage"
@@ -49,6 +50,21 @@ func TestQueue(t *testing.T) {
 	for i := 12; i <= 20; i++ {
 		res = q.Pop()
 		if res != i {
+			t.Errorf("expected: %d, actual: %d", i, res)
+		}
+	}
+
+}
+
+func TestQueueExpand(t *testing.T) {
+	q := storage.NewQueue(16)
+	for i := 0; i < 1030; i++ {
+		q.Push(i)
+	}
+	for i := 0; i < 1030; i++ {
+		res := q.Pop()
+		if res != i {
+			fmt.Printf("%d", res)
 			t.Errorf("expected: %d, actual: %d", i, res)
 		}
 	}

--- a/storage/table.go
+++ b/storage/table.go
@@ -65,7 +65,6 @@ func (t *Table) AddColumn(name string, ty Type) {
 		pos = last.pos + last.ty.size
 	}
 	t.cols = append(t.cols, Column{ty: ty, name: name, pos: pos})
-	// fmt.Println(s.cols[len(s.cols)-1])
 }
 
 func (t *Table) addRecord(rec Record) {
@@ -87,12 +86,11 @@ func (t *Table) addRecord(rec Record) {
 			newRootPage := newNonLeafPage()
 			blk := newUniqueBlockId()
 			ptb.set(blk, newRootPage)
-			newRootPage.cells = append(newRootPage.cells, KeyCell{key: math.MaxInt32, pageIndex: t.rootBlk.blockNum})
 			newRootPage.header.rightmostPtr = 0
-			newRootPage.header.numOfPtr++
 			newRootPage.ptrs = append(newRootPage.ptrs, 1)
+			newRootPage.cells = append(newRootPage.cells, KeyCell{key: math.MaxInt32, pageIndex: t.rootBlk.blockNum})
 			newRootPage.cells = append(newRootPage.cells, KeyCell{key: splitKey, pageIndex: leftPageIndex})
-			newRootPage.header.numOfPtr++
+			newRootPage.header.numOfPtr += 2
 			t.rootBlk = blk
 		}
 	}

--- a/storage/table_test.go
+++ b/storage/table_test.go
@@ -17,6 +17,20 @@ func cleanDisk(t *testing.T) {
 	os.Remove(diskDir + "/testfile")
 }
 
+func TestStorageEasy(t *testing.T) {
+	cleanDisk(t)
+
+	tb := storage.NewTable()
+	tb.AddColumn("hoge", storage.IntergerType)
+	tb.AddColumn("fuga", storage.IntergerType)
+	tb.AddColumn("piyo", storage.IntergerType)
+
+	tb.Add(2, -13, 89)
+	tb.Add(10000, 4, 44)
+	tb.Add(500, 5, 90)
+	tb.Add(10000, 4, 44)
+	tb.Add(-345, 77, 43)
+}
 func TestStorage(t *testing.T) {
 	cleanDisk(t)
 
@@ -31,6 +45,7 @@ func TestStorage(t *testing.T) {
 	tb.Add(-345, 77, 43)
 	tb.Add(-100, 89, 111)
 	tb.Add(0, 0, 0)
+	tb.Add(80000, 10, 0)
 	res, err := tb.Select("hoge", "fuga", "piyo", "fuga")
 	if err != nil {
 		t.Error("failure select")


### PR DESCRIPTION
- Pageを確保するときに実体を持たないようにした
- ページの空き領域のチェックを読みやすくした
- 関数の配置を調整
- rightmostkeyの追加
- KeyValueCellの実装
- b+treeの実装
- 使っていない関数を削除

必要に迫られてqueueも実装しました
- queueの実装
- queueへいくらでもpushできるようにした

