### PR TITLE
refactor: transactionとstorageの棲み分けをした

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,1 @@
-export DISK=$(pwd)/storage/disk/
+export DISK=$(pwd)/disk/

--- a/storage/buffermgr.go
+++ b/storage/buffermgr.go
@@ -33,7 +33,7 @@ func (ptb *PageTable) flush() {
 		curBlk := newBlockId(uint32(curBlkNum))
 		curBuffId := ptb.table[int(curBlkNum)]
 		delete(ptb.table, int(curBlkNum))
-		fm.write(curBlk, bm.pool[curBuffId].page().toBytes())
+		fm.Write(curBlk, bm.pool[curBuffId].page().toBytes())
 		bm.pool[curBuffId] = nil
 
 	}
@@ -65,7 +65,7 @@ func (ptb *PageTable) makeSpace() {
 				ptb.queue.Push(dropBlkNum)
 			} else {
 				delete(ptb.table, int(dropBlkNum))
-				fm.write(dropBlk, bm.pool[dropBuffId].page().toBytes())
+				fm.Write(dropBlk, bm.pool[dropBuffId].page().toBytes())
 				bm.pool[dropBuffId] = nil
 				break
 			}
@@ -193,7 +193,7 @@ func (bm *BufferMgr) allocate(buff *Buffer) int {
 }
 
 func (bm *BufferMgr) load(blk BlockId) int {
-	n, bytes := fm.read(blk)
+	n, bytes := fm.Read(blk)
 	if n == 0 {
 		panic(errors.New("invalid BlockId was selected"))
 	}

--- a/storage/filemgr.go
+++ b/storage/filemgr.go
@@ -5,20 +5,22 @@ import (
 )
 
 type FileMgr struct {
+	fileName  string
 	basePath  string
 	blockSize int64
 }
 
-func newFileMgr() *FileMgr {
+func NewFileMgr(fileName string) *FileMgr {
 	diskDir := os.Getenv("DISK")
 	return &FileMgr{
+		fileName:  fileName,
 		basePath:  diskDir,
 		blockSize: PageSize,
 	}
 }
 
-func (fm *FileMgr) write(blk BlockId, bytes []byte) {
-	file, err := os.OpenFile(fm.basePath+"testfile", os.O_WRONLY|os.O_CREATE, 0644)
+func (fm *FileMgr) Write(blk BlockId, bytes []byte) {
+	file, err := os.OpenFile(fm.basePath+fm.fileName, os.O_WRONLY|os.O_CREATE, 0644)
 	if err != nil {
 		panic(err)
 	}
@@ -35,8 +37,8 @@ func (fm *FileMgr) write(blk BlockId, bytes []byte) {
 	}
 }
 
-func (fm *FileMgr) read(blk BlockId) (int, []byte) {
-	file, err := os.Open(fm.basePath + "testfile")
+func (fm *FileMgr) Read(blk BlockId) (int, []byte) {
+	file, err := os.Open(fm.basePath + fm.fileName)
 	if err != nil {
 		panic(err)
 	}

--- a/storage/filemgr.go
+++ b/storage/filemgr.go
@@ -19,6 +19,11 @@ func NewFileMgr(fileName string) *FileMgr {
 	}
 }
 
+func (fm *FileMgr) Clean() {
+	diskDir := os.Getenv("DISK")
+	os.Remove(diskDir + fm.fileName)
+}
+
 func (fm *FileMgr) Write(blk BlockId, bytes []byte) {
 	file, err := os.OpenFile(fm.basePath+fm.fileName, os.O_WRONLY|os.O_CREATE, 0644)
 	if err != nil {

--- a/storage/table.go
+++ b/storage/table.go
@@ -6,13 +6,21 @@ import (
 	"fmt"
 	"math"
 	"strings"
-
-	"github.com/tychyDB/transaction"
 )
 
 var fm = NewFileMgr("testfile")
 var bm = newBufferMgr()
 var ptb = newPageTable()
+
+func Clean() {
+	fm.Clean()
+}
+
+func Reset() {
+	UniqueBlockId = 0
+	bm = newBufferMgr()
+	ptb = newPageTable()
+}
 
 type Column struct {
 	ty   Type
@@ -54,12 +62,6 @@ type Table struct {
 	cols     []Column
 	rootBlk  BlockId
 	metaPage *MetaPage
-}
-
-func Reset() {
-	UniqueBlockId = 0
-	bm = newBufferMgr()
-	ptb = newPageTable()
 }
 
 func NewTable() Table {

--- a/storage/table.go
+++ b/storage/table.go
@@ -10,7 +10,7 @@ import (
 	"github.com/tychyDB/transaction"
 )
 
-var fm = newFileMgr()
+var fm = NewFileMgr("testfile")
 var bm = newBufferMgr()
 var ptb = newPageTable()
 
@@ -71,7 +71,7 @@ func NewTable() Table {
 	if metaBlk.blockNum != 0 {
 		panic(errors.New("Place a meta page at the top of the file."))
 	}
-	fm.write(metaBlk, t.metaPage.toBytes())
+	fm.Write(metaBlk, t.metaPage.toBytes())
 
 	// rootノード
 	root := newPage(false)
@@ -87,7 +87,7 @@ func NewTableFromFIle() Table {
 	if blk.blockNum != 0 {
 		panic(errors.New("expect 0"))
 	}
-	_, bytes := fm.read(blk)
+	_, bytes := fm.Read(blk)
 	t.metaPage = newMetaPageFromBytes(bytes)
 	t.rootBlk = t.metaPage.rootBlk
 	t.cols = t.metaPage.cols
@@ -96,7 +96,7 @@ func NewTableFromFIle() Table {
 
 func (t *Table) Flush() {
 	ptb.flush()
-	fm.write(t.metaPage.metaBlk, t.metaPage.toBytes())
+	fm.Write(t.metaPage.metaBlk, t.metaPage.toBytes())
 }
 
 func (t *Table) AddColumn(name string, ty Type) {

--- a/storage/table.go
+++ b/storage/table.go
@@ -69,7 +69,7 @@ func NewTable() Table {
 	metaBlk := newUniqueBlockId()
 	t.metaPage = newMetaPage(metaBlk)
 	if metaBlk.blockNum != 0 {
-		panic(errors.New("Place a meta page at the top of the file."))
+		panic(errors.New("place a meta page at the top of the file"))
 	}
 	fm.Write(metaBlk, t.metaPage.toBytes())
 

--- a/storage/table.go
+++ b/storage/table.go
@@ -180,7 +180,25 @@ func (t *Table) Add(args ...interface{}) error {
 	return nil
 }
 
-func (t *Table) Update(prColName string, prVal interface{}, targetColName string, replaceTo interface{}) transaction.UpdateInfo {
+type UpdateInfo struct {
+	PageIdx uint32
+	PtrIdx  uint32
+	ColNum  uint32
+	From    []byte
+	To      []byte
+}
+
+func NewUpdateInfo(pageIdx uint32, ptrIdx uint32, colNum uint32, from []byte, to []byte) UpdateInfo {
+	info := UpdateInfo{}
+	info.PageIdx = pageIdx
+	info.PtrIdx = ptrIdx
+	info.ColNum = colNum
+	info.From = from
+	info.To = to
+	return info
+}
+
+func (t *Table) Update(prColName string, prVal interface{}, targetColName string, replaceTo interface{}) UpdateInfo {
 	rootPage := ptb.pin(t.rootBlk)
 	if rootPage.header.numOfPtr == 0 {
 		panic(errors.New("unexpected"))
@@ -266,7 +284,7 @@ func (t *Table) Update(prColName string, prVal interface{}, targetColName string
 	curPage.cells[cellIdx] = KeyValueCell{key: rec.getKey(), rec: rec}
 
 	// UpdateInfoの作成
-	updateInfo := transaction.NewUpdateInfo(curBlk.blockNum, ptrIdx, uint32(targetColIndex), fromBuf, toBuf)
+	updateInfo := NewUpdateInfo(curBlk.blockNum, ptrIdx, uint32(targetColIndex), fromBuf, toBuf)
 	return updateInfo
 }
 

--- a/storage/table_test.go
+++ b/storage/table_test.go
@@ -1,20 +1,13 @@
 package storage_test
 
 import (
-	"os"
 	"strings"
 	"testing"
 
 	"github.com/tychyDB/storage"
 )
 
-func cleanDisk(t *testing.T) {
-	diskDir := os.Getenv("DISK")
-	os.Remove(diskDir + "/testfile")
-}
-
 func createTable(t *testing.T) {
-	cleanDisk(t)
 	storage.Reset()
 
 	tb := storage.NewTable()
@@ -42,7 +35,6 @@ func TestDebug(t *testing.T) {
 }
 
 func TestStorageEasy(t *testing.T) {
-	cleanDisk(t)
 	storage.Reset()
 
 	tb := storage.NewTable()
@@ -57,7 +49,6 @@ func TestStorageEasy(t *testing.T) {
 	tb.Add(-345, 77, 43)
 }
 func TestStorage(t *testing.T) {
-	cleanDisk(t)
 	storage.Reset()
 
 	tb := storage.NewTable()
@@ -108,7 +99,6 @@ func TestStorage(t *testing.T) {
 }
 
 func TestStorageChar(t *testing.T) {
-	cleanDisk(t)
 	storage.Reset()
 
 	countryTable := storage.NewTable()

--- a/transaction/log.go
+++ b/transaction/log.go
@@ -3,6 +3,8 @@ package transaction
 import (
 	"errors"
 	"fmt"
+
+	"github.com/tychyDB/storage"
 )
 
 var UniqueLsn uint32
@@ -21,13 +23,15 @@ func init() {
 }
 
 type LogMgr struct {
+	fm         storage.FileMgr
 	flashedLSN uint32
 	logPool    []*Log
 	logCount   uint32
 }
 
-func NewLogMgr() *LogMgr {
+func NewLogMgr(fm storage.FileMgr) *LogMgr {
 	logMgr := LogMgr{}
+	logMgr.fm = fm
 	logMgr.flashedLSN = 0
 	logMgr.logPool = make([]*Log, MaxLogPoolSize)
 	logMgr.logCount = 0

--- a/transaction/log.go
+++ b/transaction/log.go
@@ -50,7 +50,7 @@ func (lm *LogMgr) addLog(txnId, logType uint32) {
 	lm.logCount++
 }
 
-func (lm *LogMgr) addLogForUpdate(txnId, logType uint32, updateInfo UpdateInfo) {
+func (lm *LogMgr) addLogForUpdate(txnId, logType uint32, updateInfo storage.UpdateInfo) {
 	if logType != UPDATE {
 		panic(errors.New("log type expected to be UPDATE"))
 	}
@@ -67,29 +67,11 @@ func (lm *LogMgr) Print() {
 	}
 }
 
-type UpdateInfo struct {
-	pageIdx uint32
-	ptrIdx  uint32
-	colNum  uint32
-	from    []byte
-	to      []byte
-}
-
-func NewUpdateInfo(pageIdx uint32, ptrIdx uint32, colNum uint32, from []byte, to []byte) UpdateInfo {
-	info := UpdateInfo{}
-	info.pageIdx = pageIdx
-	info.ptrIdx = ptrIdx
-	info.colNum = colNum
-	info.from = from
-	info.to = to
-	return info
-}
-
 type Log struct {
 	txnId      uint32
 	lsn        uint32
 	logType    uint32
-	updateInfo UpdateInfo
+	updateInfo storage.UpdateInfo
 }
 
 func newUniqueLog(txnId uint32, logType uint32) *Log {
@@ -104,7 +86,7 @@ func (log *Log) info() {
 	fmt.Printf("%7d, %7d, %7d, ", log.txnId, log.lsn, log.logType)
 	if log.logType == UPDATE {
 		u := log.updateInfo
-		fmt.Printf("%7d, %7d, %7d, %7b, %7b", u.pageIdx, u.ptrIdx, u.colNum, u.from, u.to)
+		fmt.Printf("%7d, %7d, %7d, %7b, %7b", u.PageIdx, u.PtrIdx, u.ColNum, u.From, u.To)
 	} else {
 		fmt.Printf("       ,        ,        ,         ,        ")
 	}

--- a/transaction/transaction.go
+++ b/transaction/transaction.go
@@ -1,5 +1,7 @@
 package transaction
 
+import "github.com/tychyDB/storage"
+
 var UniqueTxnId uint32
 
 func init() {
@@ -34,7 +36,7 @@ func (txn *Transaction) Commit() {
 func (txn *Transaction) Abort() {
 	txn.lm.addLog(txn.txnId, ABORT)
 }
-func (txn *Transaction) Update(updateInfo UpdateInfo) {
+func (txn *Transaction) Update(updateInfo storage.UpdateInfo) {
 	txn.lm.addLogForUpdate(txn.txnId, UPDATE, updateInfo)
 }
 

--- a/transaction/transaction_test.go
+++ b/transaction/transaction_test.go
@@ -40,9 +40,10 @@ func createTable(t *testing.T) {
 func TestTxn(t *testing.T) {
 	createTable(t)
 	storage.Reset()
+	logfm := storage.NewFileMgr("logfile")
+
 	tb := storage.NewTableFromFIle()
-	tb.Viz("hoge")
-	lm := transaction.NewLogMgr()
+	lm := transaction.NewLogMgr(*logfm)
 	txn := transaction.NewTransaction(lm)
 	txn.Begin()
 	updateInfo := tb.Update("hoge", 2, "fuga", 33)


### PR DESCRIPTION
- fileMgrを再利用できるようにする
- DISKの場所を変更
- logMgrにFileMgrをもたせる
- format error message
- add clean to fileMgr
- move UpdateInfo to storage
